### PR TITLE
ci: GitHub Actions CI/CDワークフローを追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --extra dev
 
       - name: Run ruff check
         run: uv run ruff check src/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv pip install -e ".[dev]"
+        run: uv sync --dev
 
       - name: Run ruff check
         run: uv run ruff check src/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,34 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.14'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --extra dev
-
-      - name: Run ruff check
-        run: uv run ruff check src/
-
-      - name: Run ruff format --check
-        run: uv run ruff format --check src/
-
-      - name: Run mypy
-        run: uv run mypy src/
-
-      - name: Run pytest
-        run: uv run pytest tests/ -v
+    uses: ./.github/workflows/ci.yml
 
   deploy:
     needs: test

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,68 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]"
+
+      - name: Run ruff check
+        run: uv run ruff check src/
+
+      - name: Run ruff format --check
+        run: uv run ruff format --check src/
+
+      - name: Run mypy
+        run: uv run mypy src/
+
+      - name: Run pytest
+        run: uv run pytest tests/ -v
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::298557745729:role/GitHubActionsDeployRole
+          aws-region: ap-northeast-1
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install AWS SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: SAM build
+        run: sam build
+
+      - name: SAM deploy
+        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --extra dev
 
       - name: Run ruff check
         run: uv run ruff check src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: uv pip install -e ".[dev]"
+        run: uv sync --dev
 
       - name: Run ruff check
         run: uv run ruff check src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv pip install -e ".[dev]"
+
+      - name: Run ruff check
+        run: uv run ruff check src/
+
+      - name: Run ruff format --check
+        run: uv run ruff format --check src/
+
+      - name: Run mypy
+        run: uv run mypy src/
+
+      - name: Run pytest
+        run: uv run pytest tests/ -v


### PR DESCRIPTION
## Summary
- PR作成時にruff/mypy/pytestを自動実行するCIワークフローを追加
- mainマージ時にCI + SAMデプロイを自動実行するCDワークフローを追加
- OIDC認証でAWSに接続（アクセスキー不要）

## Test plan
- [ ] GitHub ActionsタブでCIワークフローが起動することを確認
- [ ] ruff check / ruff format --check / mypy / pytest がすべて成功することを確認
- [ ] PRをmainにマージしてCDワークフローが起動することを確認
- [ ] sam deploy が成功してLambda関数が更新されることを確認