### PR TITLE
feat: メール配信スケジュールを火曜・金曜のみに変更

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -64,11 +64,11 @@ Resources:
               Resource:
                 - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/ai-curated-newsletter/*'
       Events:
-        DailySchedule:
+        WeeklySchedule:
           Type: Schedule
           Properties:
-            Schedule: cron(0 0 * * ? *)  # 毎日JST 09:00 (UTC 00:00)
-            Description: 毎日JST 09:00にニュースレターを実行
+            Schedule: cron(0 0 ? * 3,6 *)  # 火曜・金曜 JST 09:00 (UTC 00:00)
+            Description: 火曜・金曜 JST 09:00にニュースレターを実行
             Enabled: true
 
   # DynamoDB Cache Table


### PR DESCRIPTION
## Summary

- 毎日配信（JST 09:00）から週2回配信に変更
- 配信曜日: 火曜日・金曜日（JST 09:00）
- `cron(0 0 * * ? *)` → `cron(0 0 ? * 3,6 *)`

## Changes

- `template.yaml`: EventBridge スケジュール設定を更新
  - イベント名: `DailySchedule` → `WeeklySchedule`
  - cron式: 毎日 → 火曜(3)・金曜(6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)